### PR TITLE
Add instance Show (SpecCommand context m t)

### DIFF
--- a/sandwich/src/Test/Sandwich/Types/Spec.hs
+++ b/sandwich/src/Test/Sandwich/Types/Spec.hs
@@ -250,6 +250,9 @@ type SpecFree context m a = Free (SpecCommand context m) a
 
 makeFree_ ''SpecCommand
 
+instance Show t => Show (SpecCommand context m t) where
+  showsPrec = liftShowsPrec showsPrec showList
+
 instance Show1 (SpecCommand context m) where
   liftShowsPrec sp _ d (Before'' {..}) = showsUnaryWith sp [i|Before[#{label}]<#{show subspec}>|] d next
   liftShowsPrec sp _ d (After'' {..}) = showsUnaryWith sp [i|After[#{label}]<#{show subspec}>|] d next


### PR DESCRIPTION
It does not harm and provides compatibility with a [CLC proposal](https://github.com/haskell/core-libraries-committee/issues/10) to make `forall a. Eq a => Eq (f a)` a superclass of `Eq1 f`.