### PR TITLE
Import `Control.Monad` to enable building with GHC 9.6

### DIFF
--- a/sandwich/src/Test/Sandwich/Formatters/Print/Common.hs
+++ b/sandwich/src/Test/Sandwich/Formatters/Print/Common.hs
@@ -3,6 +3,7 @@
 module Test.Sandwich.Formatters.Print.Common where
 
 import Control.Monad.Reader
+import Control.Monad
 import System.IO
 import Test.Sandwich.Formatters.Print.CallStacks
 import Test.Sandwich.Formatters.Print.Logs

--- a/sandwich/src/Test/Sandwich/Formatters/Print/FailureReason.hs
+++ b/sandwich/src/Test/Sandwich/Formatters/Print/FailureReason.hs
@@ -9,6 +9,7 @@ module Test.Sandwich.Formatters.Print.FailureReason (
 
 import Control.Exception.Safe
 import Control.Monad.Reader
+import Control.Monad
 import qualified Data.List as L
 import Data.String.Interpolate
 import System.IO

--- a/sandwich/src/Test/Sandwich/Formatters/Print/Logs.hs
+++ b/sandwich/src/Test/Sandwich/Formatters/Print/Logs.hs
@@ -5,6 +5,7 @@ import Control.Concurrent.STM
 import Control.Monad.IO.Class
 import Control.Monad.Logger
 import Control.Monad.Reader
+import Control.Monad
 import Data.String.Interpolate
 import System.IO
 import Test.Sandwich.Formatters.Print.Color


### PR DESCRIPTION
GHC 9.6 bundles mtl-2.3, which removed `Control.Monad` reexports from a bunch of modules.