### PR TITLE
fix: exit with failure status when tests fail

### DIFF
--- a/sandwich/src/Test/Sandwich.hs
+++ b/sandwich/src/Test/Sandwich.hs
@@ -85,6 +85,7 @@ import GHC.IO.Encoding
 import Options.Applicative
 import qualified Options.Applicative as OA
 import System.Environment
+import System.Exit
 import System.FilePath
 import Test.Sandwich.ArgParsing
 import Test.Sandwich.Contexts
@@ -118,7 +119,9 @@ import System.Win32.Console (setConsoleOutputCP)
 
 -- | Run the spec with the given 'Options'.
 runSandwich :: Options -> CoreSpec -> IO ()
-runSandwich options spec = void $ runSandwich' Nothing options spec
+runSandwich options spec = do
+  (_exitReason, failures) <- runSandwich' Nothing options spec
+  when (0 < failures) $ exitFailure
 
 -- | Run the spec, configuring the options from the command line.
 runSandwichWithCommandLineArgs :: Options -> TopSpecWithOptions -> IO ()


### PR DESCRIPTION
This change makes the `runSandwich` function exit
with a non-zero status code (1) when any test failures occur.
This helps CI systems properly detect test failures,
as previously the process would exit with status 0 even
when tests failed due to the exception handling in `runSandwich'`.
