### PR TITLE
feat: replace from `haskell-src-exts` to `ghc-lib` and `ghc-lib-parser`

### DIFF
--- a/sandwich/package.yaml
+++ b/sandwich/package.yaml
@@ -20,6 +20,7 @@ default-extensions:
 - NamedFieldPuns
 - NumericUnderscores
 - OverloadedStrings
+- PackageImports
 - QuasiQuotes
 - RecordWildCards
 - ScopedTypeVariables
@@ -62,8 +63,10 @@ dependencies:
 - vty-crossplatform
 
 # For spec discovery. Move to its own package?
-- template-haskell
+- ghc-lib
+- ghc-lib-parser
 - haskell-src-exts
+- template-haskell
 
 when:
 - condition: "!os(windows)"

--- a/sandwich/sandwich.cabal
+++ b/sandwich/sandwich.cabal
@@ -105,6 +105,7 @@ library
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
+      PackageImports
       QuasiQuotes
       RecordWildCards
       ScopedTypeVariables
@@ -124,6 +125,8 @@ library
     , exceptions
     , filepath
     , free
+    , ghc-lib
+    , ghc-lib-parser
     , haskell-src-exts
     , microlens
     , microlens-th
@@ -168,6 +171,7 @@ executable sandwich-demo
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
+      PackageImports
       QuasiQuotes
       RecordWildCards
       ScopedTypeVariables
@@ -187,6 +191,8 @@ executable sandwich-demo
     , exceptions
     , filepath
     , free
+    , ghc-lib
+    , ghc-lib-parser
     , haskell-src-exts
     , microlens
     , microlens-th
@@ -229,6 +235,7 @@ executable sandwich-discover
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
+      PackageImports
       QuasiQuotes
       RecordWildCards
       ScopedTypeVariables
@@ -248,6 +255,8 @@ executable sandwich-discover
     , exceptions
     , filepath
     , free
+    , ghc-lib
+    , ghc-lib-parser
     , haskell-src-exts
     , microlens
     , microlens-th
@@ -295,6 +304,7 @@ executable sandwich-test
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
+      PackageImports
       QuasiQuotes
       RecordWildCards
       ScopedTypeVariables
@@ -314,6 +324,8 @@ executable sandwich-test
     , exceptions
     , filepath
     , free
+    , ghc-lib
+    , ghc-lib-parser
     , haskell-src-exts
     , microlens
     , microlens-th
@@ -362,6 +374,7 @@ test-suite sandwich-test-suite
       NamedFieldPuns
       NumericUnderscores
       OverloadedStrings
+      PackageImports
       QuasiQuotes
       RecordWildCards
       ScopedTypeVariables
@@ -381,6 +394,8 @@ test-suite sandwich-test-suite
     , exceptions
     , filepath
     , free
+    , ghc-lib
+    , ghc-lib-parser
     , haskell-src-exts
     , microlens
     , microlens-th

--- a/sandwich/src/Test/Sandwich/TH.hs
+++ b/sandwich/src/Test/Sandwich/TH.hs
@@ -22,8 +22,8 @@ import qualified Data.Map as M
 import Data.Maybe
 import Data.String.Interpolate
 import qualified Data.Text as T
-import Language.Haskell.TH
-import Language.Haskell.TH.Syntax
+import "template-haskell" Language.Haskell.TH
+import "template-haskell" Language.Haskell.TH.Syntax
 import Safe
 import System.Directory
 import System.FilePath as F

--- a/sandwich/src/Test/Sandwich/TH/HasMainFunction.hs
+++ b/sandwich/src/Test/Sandwich/TH/HasMainFunction.hs
@@ -1,18 +1,28 @@
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE TemplateHaskell #-}
-
-module Test.Sandwich.TH.HasMainFunction (
-  fileHasMainFunction
-  , ShouldWarnOnParseError(..)
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ViewPatterns #-}
+module Test.Sandwich.TH.HasMainFunction
+  ( fileHasMainFunction
+  , ShouldWarnOnParseError (..)
   ) where
 
 import Control.Monad
+import Data.Char
+import Data.Function
+import qualified Data.List as L
+import qualified Data.Map as M
+import Data.Maybe
 import Data.String.Interpolate
-import Language.Haskell.Exts hiding (name)
-import Language.Haskell.TH (Q, runIO, reportWarning)
-
--- import Debug.Trace
-
+import qualified Data.Text as T
+import GHC
+import GHC.Types.Name
+import GHC.Unit.Module.ModSummary
+import Safe
+import System.Directory
+import System.FilePath as F
+import Test.Sandwich.TH.ModuleMap
+import Test.Sandwich.Types.Spec hiding (location)
+import "template-haskell" Language.Haskell.TH hiding (Name)
 
 data ShouldWarnOnParseError = WarnOnParseError | NoWarnOnParseError
   deriving (Eq)
@@ -20,40 +30,38 @@ data ShouldWarnOnParseError = WarnOnParseError | NoWarnOnParseError
 -- | Use haskell-src-exts to determine if a give Haskell file has an exported main function
 -- Parse with all extensions enabled, which will hopefully parse anything
 fileHasMainFunction :: FilePath -> ShouldWarnOnParseError -> Q Bool
-fileHasMainFunction path shouldWarnOnParseError = runIO (parseFileWithExts [x | x@(EnableExtension _) <- knownExtensions] path) >>= \case
-  x@(ParseFailed {}) -> do
-    when (shouldWarnOnParseError == WarnOnParseError) $
-      reportWarning [i|Failed to parse #{path}: #{x}|]
-    return False
-  ParseOk (Module _ (Just moduleHead) _ _ decls) -> do
-    -- traceM [i|Sucessfully parsed #{path}: #{moduleHead}|]
-    case moduleHead of
-      ModuleHead _ _ _ (Just (ExportSpecList _ (any isMainFunction -> True))) -> do
-        -- traceM [i|FOUND MAIN FUNCTION FOR #{path}|]
-        return True
-      ModuleHead _ _ _ Nothing -> do
-        -- traceM [i|LOOKING FOR DECLS: #{decls}|]
-        return $ any isMainDecl decls
-      _ -> return False
-  ParseOk _ -> do
-    reportWarning [i|Successfully parsed #{path} but no module head found|]
-    return False
+fileHasMainFunction path shouldWarnOnParseError = do
+  hasMain <- runIO $ hasMainFunction path
+  case shouldWarnOnParseError of
+    WarnOnParseError -> do
+      unless hasMain $ reportWarning [i|Warning: File #{path} does not have an exported main function|]
+      return hasMain
+    NoWarnOnParseError -> return hasMain
 
-isMainFunction :: ExportSpec l -> Bool
-isMainFunction (EVar _ name) = isMainFunctionQName name
-isMainFunction _ = False
+hasMainFunction :: FilePath -> IO Bool
+hasMainFunction filepath = do
+  runGhc Nothing $ do
+    dflags <- getSessionDynFlags
+    setSessionDynFlags dflags
+    target <- guessTarget filepath Nothing Nothing
+    addTarget target
+    result <- load LoadAllTargets
+    case result of
+      Succeeded -> do
+        modGraph <- getModuleGraph
+        case L.find (\ms -> msHsFilePath ms == filepath) (mgModSummaries modGraph) of
+          Nothing -> return False
+          Just modSummary -> do
+            let modName = moduleNameString (ms_mod_name modSummary)
+            mod <- findModule (mkModuleName modName) Nothing
+            modInfo <- getModuleInfo mod
+            case modInfo of
+              Nothing -> return False
+              Just mi -> do
+                let exports = modInfoExports mi
+                return $ any isMainName exports
+      Failed -> return False
 
-isMainFunctionQName :: QName l -> Bool
-isMainFunctionQName (Qual _ _ name) = isMainFunctionName name
-isMainFunctionQName (UnQual _ name) = isMainFunctionName name
-isMainFunctionQName _ = False
-
-isMainFunctionName :: Name l -> Bool
-isMainFunctionName (Ident _ "main") = True
-isMainFunctionName (Symbol _ "main") = True
-isMainFunctionName _ = False
-
-isMainDecl :: Decl l -> Bool
-isMainDecl (PatBind _ (PVar _ (Ident _ "main")) _ _) = True
--- isMainDecl decl = trace [i|Looking at decl: #{decl}|] False
-isMainDecl _ = False
+-- | The arg is Main.
+isMainName :: Name -> Bool
+isMainName name = getOccString name == "main"

--- a/sandwich/src/Test/Sandwich/Types/TestTimer/LensRules.hs
+++ b/sandwich/src/Test/Sandwich/Types/TestTimer/LensRules.hs
@@ -1,10 +1,9 @@
-
 module Test.Sandwich.Types.TestTimer.LensRules (
   testTimerLensRules
   ) where
 
 import Data.Char (toLower, toUpper)
-import Language.Haskell.TH
+import "template-haskell" Language.Haskell.TH
 import Lens.Micro
 import Lens.Micro.TH
 


### PR DESCRIPTION
closed #104

I've been trying to implement this using the ghc-lib API.
I've managed to get it to build, but I'm opening this as a draft since I haven't tested whether it actually works.
Even if it does work, I'm concerned about using packages like `ghc-lib-parser` that are prone to breaking with version updates.
Having it as a fallback option that can be toggled with a flag might not be a completely unreasonable choice.