### PR TITLE
fix(expectations): type of `xit` closer to the type of `it`

### DIFF
--- a/sandwich/src/Test/Sandwich/Expectations.hs
+++ b/sandwich/src/Test/Sandwich/Expectations.hs
@@ -29,7 +29,7 @@ pendingWith :: (HasCallStack, MonadIO m) => String -> m a
 pendingWith msg = throwIO $ Pending (Just callStack) (Just msg)
 
 -- | Shorthand for a pending test example. You can quickly mark an 'it' node as pending by putting an "x" in front of it.
-xit :: (HasCallStack, MonadIO m) => String -> ExampleT context m1 () -> SpecFree context m ()
+xit :: (HasCallStack, MonadIO m) => String -> ExampleT context m () -> SpecFree context m ()
 xit name _ex = it name (throwIO $ Pending (Just callStack) Nothing)
 
 -- * Expecting failures


### PR DESCRIPTION
I made the type of `xit` closer to the type of `it`.
This is to increase the patterns that can be built by rewriting from `it`.
The traditional signature where input and output types are not linked may fail type inference.
For example, when I was using `RIO`-based tests, rewriting to `xit` sometimes failed to build.
While it was possible to work around this by writing detailed type annotations,
I believe `xit` should, by its role, be able to build successfully when rewritten from `it`.
Conversely, there is a possibility that this change may cause things
that previously built when passed to `xit` to no longer build,
but since those would not build when rewritten to `it`,
I think this is not a practical issue considering the role of `xit`.
